### PR TITLE
chore:  배포 사전 준비 및 CICD 기능 추가

### DIFF
--- a/.github/workflows/sync-to-personal.yml
+++ b/.github/workflows/sync-to-personal.yml
@@ -1,0 +1,20 @@
+name: Sync to Personal Fork
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v3
+
+      - name: Push to personal fork
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git remote add fork https://x-access-token:${{ secrets.PERSONAL_TOKEN }}@github.com/yundol777/QuizUp-FE.git
+          git push --force fork main

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+.env
 dist-ssr
 *.local
 


### PR DESCRIPTION
## 📝 PR 설명

- 임시로 vercel을 이용한 배포 진행
- 팀 레포 main에 push 이후 개인 레포로 자동으로 반영되도록 CI/CD 구현 (github action)

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #25 
