### PR TITLE
fix: 모바일 화면에서 깨지는 레이아웃 수정 및 채팅 스크롤 이동 추가

### DIFF
--- a/src/components/layout/MobileHomeLayout/index.jsx
+++ b/src/components/layout/MobileHomeLayout/index.jsx
@@ -10,7 +10,7 @@ const mockClassData = {
 
 const MobileHomeLayout = () => {
   return (
-    <div className="bg-primary-base h-screen flex flex-col">
+    <div className="bg-primary-base h-[100dvh] flex flex-col overflow-hidden">
       <div className="flex items-center gap-4 py-2 px-4 bg-primary-dark text-primary-soft">
         <img src={icon} alt="app-icon" className="w-7 h-8.5" />
         <h1 className="flex-1 text-xs font-semibold">

--- a/src/components/layout/MobileLayout/index.jsx
+++ b/src/components/layout/MobileLayout/index.jsx
@@ -5,7 +5,7 @@ const MobileLayout = () => {
   return (
     <div
       style={{ backgroundImage: `url(${bgImage})` }}
-      className="h-screen px-10 py-20 bg-cover bg-center flex flex-col gap-14 items-center justify-start"
+      className="h-[100dvh] px-10 py-20 bg-cover flex flex-col gap-14 items-center justify-start overflow-hidden"
     >
       <Outlet />
     </div>

--- a/src/components/mobile/chat/ChatInput/index.jsx
+++ b/src/components/mobile/chat/ChatInput/index.jsx
@@ -51,7 +51,7 @@ const ChatInput = ({ role, onSend, onCheck, onOXQuiz, onDraw, onQuiz }) => {
       </div>
 
       {isModalOpen && (
-        <div className="absolute ml-3 top-0 left-0 -translate-y-full px-6 py-0 bg-primary-dark rounded-full flex items-center justify-between w-[200px] h-[48px] border border-primary-border shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]">
+        <div className="absolute ml-3 top-0 left-0 -translate-y-full px-6 py-0 bg-primary-dark rounded-full flex items-center justify-between w-[200px] h-[48px] border border-primary-border shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] z-5">
           <img
             src={quizIcon}
             alt="quiz"

--- a/src/components/mobile/chat/ChatMessages/index.jsx
+++ b/src/components/mobile/chat/ChatMessages/index.jsx
@@ -6,28 +6,48 @@ import MessageCheck from "../message/Check";
 import MessageOXQuiz from "../message/OXQuiz";
 import MessageDraw from "../message/Draw";
 import MessageQuiz from "../message/Quiz";
-
-// const messages = [
-//   {
-//     id: 1,
-//     type: "oxquiz",
-//     count: [12, 11],
-//     role: "student",
-//     isChecked: true,
-//   },
-//   {
-//     id: 2,
-//     type: "check",
-//     count: 10,
-//     role: "professor",
-//     isChecked: false,
-//   },
-// ];
+import { useEffect, useRef } from "react";
 
 const ChatMessages = ({ messages, toggleCheck, toggleOXQuiz }) => {
-  console.log(messages);
+  const scrollRef = useRef(null);
+  const prevLengthRef = useRef(0);
+
+  const scrollToBottom = () => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTo({
+        top: el.scrollHeight,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const isAtBottom = () => {
+    const el = scrollRef.current;
+    if (!el) return false;
+    const diff = el.scrollHeight - el.scrollTop - el.clientHeight;
+    return diff < 150;
+  };
+
+  // 초기 렌더 시
+  useEffect(() => {
+    if (messages.length > 0 && prevLengthRef.current === 0) {
+      requestAnimationFrame(() => scrollToBottom());
+    }
+  }, [messages]);
+
+  // 이후 메시지 증가 시
+  useEffect(() => {
+    if (messages.length > prevLengthRef.current) {
+      if (isAtBottom()) {
+        requestAnimationFrame(() => scrollToBottom());
+      }
+    }
+    prevLengthRef.current = messages.length;
+  }, [messages]);
+
   return (
-    <div className="flex-1 px-4 py-2 space-y-2 overflow-y-auto">
+    <div ref={scrollRef} className="flex-1 px-4 py-2 space-y-2 overflow-y-auto">
       {messages.map((msg) => {
         const key = `${msg.type}-${msg.id}`;
 

--- a/src/pages/mobile/Chat/index.jsx
+++ b/src/pages/mobile/Chat/index.jsx
@@ -31,7 +31,7 @@ const MobileChat = () => {
   } = useSocket(role, roomId, token);
 
   return (
-    <div className="flex flex-col flex-1">
+    <div className="flex flex-col flex-1 overflow-hidden">
       <ChatMessages
         messages={messages}
         toggleCheck={toggleCheck}


### PR DESCRIPTION
## 📝 PR 설명

- 모바일 화면에서 키보드, 브라우저 창으로 인해 레이아웃이 뭉개지는 부분 수정
- 채팅 메세지 영역 부분, 메세지 쌓이면 레이아웃을 넘어서는 부분 수정
- 채팅 출력 시 스크롤 위치에 따른 스크롤 이동 추가
- 채팅 모달 z-index 수정

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #33 
