### PR TITLE
fix: 문제 페이지 헤더 부분 삭제 및 채팅 모달 닫힘 기능 추가

### DIFF
--- a/src/components/layout/MobileHomeLayout/index.jsx
+++ b/src/components/layout/MobileHomeLayout/index.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useParams } from "react-router-dom";
 import { FaRankingStar } from "react-icons/fa6";
 import { BiMenu } from "react-icons/bi";
 import icon from "../../../assets/icon.png";
@@ -9,16 +9,19 @@ const mockClassData = {
 };
 
 const MobileHomeLayout = () => {
+  const { quizId } = useParams();
   return (
     <div className="bg-primary-base h-[100dvh] flex flex-col overflow-hidden">
-      <div className="flex items-center gap-4 py-2 px-4 bg-primary-dark text-primary-soft">
-        <img src={icon} alt="app-icon" className="w-7 h-8.5" />
-        <h1 className="flex-1 text-xs font-semibold">
-          {mockClassData.className}
-        </h1>
-        <FaRankingStar className="w-6 h-6" />
-        <BiMenu className="w-7.5 h-7.5" />
-      </div>
+      {!quizId && (
+        <div className="flex items-center gap-4 py-2 px-4 bg-primary-dark text-primary-soft">
+          <img src={icon} alt="app-icon" className="w-7 h-8.5" />
+          <h1 className="flex-1 text-xs font-semibold">
+            {mockClassData.className}
+          </h1>
+          <FaRankingStar className="w-6 h-6" />
+          <BiMenu className="w-7.5 h-7.5" />
+        </div>
+      )}
       <Outlet />
     </div>
   );

--- a/src/components/mobile/chat/ChatInput/index.jsx
+++ b/src/components/mobile/chat/ChatInput/index.jsx
@@ -56,25 +56,37 @@ const ChatInput = ({ role, onSend, onCheck, onOXQuiz, onDraw, onQuiz }) => {
             src={quizIcon}
             alt="quiz"
             className="cursor-pointer"
-            onClick={() => onQuiz(1)}
+            onClick={() => {
+              onQuiz(1);
+              setIsModalOpen(false);
+            }}
           />
           <img
             src={checkIcon}
             alt="check"
             className="cursor-pointer"
-            onClick={onCheck}
+            onClick={() => {
+              onCheck();
+              setIsModalOpen(false);
+            }}
           />
           <img
             src={oxIcon}
             alt="o/x"
             className="cursor-pointer"
-            onClick={onOXQuiz}
+            onClick={() => {
+              onOXQuiz();
+              setIsModalOpen(false);
+            }}
           />
           <img
             src={randomIcon}
             alt="random"
             className="cursor-pointer"
-            onClick={onDraw}
+            onClick={() => {
+              onDraw();
+              setIsModalOpen(false);
+            }}
           />
         </div>
       )}

--- a/src/pages/mobile/Quiz/index.jsx
+++ b/src/pages/mobile/Quiz/index.jsx
@@ -71,7 +71,7 @@ const MobileQuiz = () => {
 
   useEffect(() => {
     if (remainingSeconds === 0) {
-      // handleSubmit();
+      handleSubmit();
     }
   }, [remainingSeconds]);
 


### PR DESCRIPTION
## 📝 PR 설명

- 모바일 화면에서 문제 페이지 출력 시 헤더 부분으로 인해 버튼이 짤리는 문제 발생
- quiz 관련 페이지에서 레이아웃 헤더 삭제 (추후 분리 예정)
- 채팅에서 모달창으로 이벤트 호출 후 모달창 자동 닫힘 기능 추가

## ✅ 체크리스트

- [x] 관련 이슈를 연결했나요? (Closes #이슈번호)
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트 또는 실행 확인을 했나요?

## 📎 관련 이슈

- closes #39
